### PR TITLE
Solve a little error with the color of the titles in the senses section.

### DIFF
--- a/src/components/sections/senses_section.tsx
+++ b/src/components/sections/senses_section.tsx
@@ -79,7 +79,7 @@ export default function SensesSection() {
           {/* Title */}
           <h2 className="text-2xl font-fancy text-center md:text-left">
             <span className={`${"text-"+sense.sense}`}>{t(sense.name)}</span>{" "}
-            <span className="text-white">{t("science")}</span>
+            <span>{t("science")}</span>
           </h2>
 
           {/* Grid of Images */}


### PR DESCRIPTION
Closes #...

__Sorry, I made a mistake on the senses section with the colors, and it was unreadable when changing the pallete to the light one. Now it's fine__

...

__I have verified the following:__
- [x] The elements I have changed look correct with `pnpm run dev`
- [ ] `pnpm run build` executes successfully
